### PR TITLE
Add/Enable ap-northeast-3 (Osaka) region

### DIFF
--- a/analyzer_baselines.tf
+++ b/analyzer_baselines.tf
@@ -43,6 +43,19 @@ module "analyzer_baseline_ap-south-1" {
   tags            = var.tags
 }
 
+module "analyzer_baseline_ap-northeast-3" {
+  source = "./modules/analyzer-baseline"
+
+  providers = {
+    aws = aws.ap-northeast-3
+  }
+
+  enabled         = local.is_analyzer_enabled && contains(var.target_regions, "ap-northeast-3")
+  analyzer_name   = var.analyzer_name
+  is_organization = local.is_master_account
+  tags            = var.tags
+}
+
 module "analyzer_baseline_ap-southeast-1" {
   source = "./modules/analyzer-baseline"
 

--- a/config_baselines.tf
+++ b/config_baselines.tf
@@ -2,6 +2,7 @@ locals {
   config_topics = [
     module.config_baseline_ap-northeast-1.config_sns_topic,
     module.config_baseline_ap-northeast-2.config_sns_topic,
+    module.config_baseline_ap-northeast-3.config_sns_topic,
     module.config_baseline_ap-south-1.config_sns_topic,
     module.config_baseline_ap-southeast-1.config_sns_topic,
     module.config_baseline_ap-southeast-2.config_sns_topic,
@@ -112,6 +113,23 @@ module "config_baseline_ap-northeast-2" {
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-2"
+  tags                          = var.tags
+}
+
+module "config_baseline_ap-northeast-3" {
+  source = "./modules/config-baseline"
+
+  providers = {
+    aws = aws.ap-northeast-3
+  }
+
+  enabled                       = contains(var.target_regions, "ap-northeast-3")
+  iam_role_arn                  = aws_iam_role.recorder.arn
+  s3_bucket_name                = local.audit_log_bucket_id
+  s3_key_prefix                 = var.config_s3_bucket_key_prefix
+  delivery_frequency            = var.config_delivery_frequency
+  sns_topic_name                = var.config_sns_topic_name
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-3"
   tags                          = var.tags
 }
 
@@ -371,6 +389,7 @@ resource "aws_config_config_rule" "iam_mfa" {
   depends_on = [
     module.config_baseline_ap-northeast-1,
     module.config_baseline_ap-northeast-2,
+    module.config_baseline_ap-northeast-3,
     module.config_baseline_ap-south-1,
     module.config_baseline_ap-southeast-1,
     module.config_baseline_ap-southeast-2,
@@ -404,6 +423,7 @@ resource "aws_config_config_rule" "unused_credentials" {
   depends_on = [
     module.config_baseline_ap-northeast-1,
     module.config_baseline_ap-northeast-2,
+    module.config_baseline_ap-northeast-3,
     module.config_baseline_ap-south-1,
     module.config_baseline_ap-southeast-1,
     module.config_baseline_ap-southeast-2,
@@ -441,6 +461,7 @@ resource "aws_config_config_rule" "user_no_policies" {
   depends_on = [
     module.config_baseline_ap-northeast-1,
     module.config_baseline_ap-northeast-2,
+    module.config_baseline_ap-northeast-3,
     module.config_baseline_ap-south-1,
     module.config_baseline_ap-southeast-1,
     module.config_baseline_ap-southeast-2,
@@ -478,6 +499,7 @@ resource "aws_config_config_rule" "no_policies_with_full_admin_access" {
   depends_on = [
     module.config_baseline_ap-northeast-1,
     module.config_baseline_ap-northeast-2,
+    module.config_baseline_ap-northeast-3,
     module.config_baseline_ap-south-1,
     module.config_baseline_ap-southeast-1,
     module.config_baseline_ap-southeast-2,

--- a/ebs_baselines.tf
+++ b/ebs_baselines.tf
@@ -20,6 +20,16 @@ module "ebs_baseline_ap-northeast-2" {
   enabled = contains(var.target_regions, "ap-northeast-2")
 }
 
+module "ebs_baseline_ap-northeast-3" {
+  source = "./modules/ebs-baseline"
+
+  providers = {
+    aws = aws.ap-northeast-3
+  }
+
+  enabled = contains(var.target_regions, "ap-northeast-3")
+}
+
 module "ebs_baseline_ap-south-1" {
   source = "./modules/ebs-baseline"
 

--- a/guardduty_baselines.tf
+++ b/guardduty_baselines.tf
@@ -42,6 +42,23 @@ module "guardduty_baseline_ap-northeast-2" {
   tags = var.tags
 }
 
+module "guardduty_baseline_ap-northeast-3" {
+  source = "./modules/guardduty-baseline"
+
+  providers = {
+    aws = aws.ap-northeast-3
+  }
+
+  enabled                      = contains(var.target_regions, "ap-northeast-3")
+  disable_email_notification   = var.guardduty_disable_email_notification
+  finding_publishing_frequency = var.guardduty_finding_publishing_frequency
+  invitation_message           = var.guardduty_invitation_message
+  master_account_id            = local.guardduty_master_account_id
+  member_accounts              = local.guardduty_member_accounts
+
+  tags = var.tags
+}
+
 module "guardduty_baseline_ap-south-1" {
   source = "./modules/guardduty-baseline"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,6 +60,7 @@ output "config_configuration_recorder" {
   value = {
     "ap-northeast-1" = module.config_baseline_ap-northeast-1.configuration_recorder
     "ap-northeast-2" = module.config_baseline_ap-northeast-2.configuration_recorder
+    "ap-northeast-3" = module.config_baseline_ap-northeast-3.configuration_recorder
     "ap-south-1"     = module.config_baseline_ap-south-1.configuration_recorder
     "ap-southeast-1" = module.config_baseline_ap-southeast-1.configuration_recorder
     "ap-southeast-2" = module.config_baseline_ap-southeast-2.configuration_recorder
@@ -82,6 +83,7 @@ output "config_sns_topic" {
   value = {
     "ap-northeast-1" = module.config_baseline_ap-northeast-1.config_sns_topic
     "ap-northeast-2" = module.config_baseline_ap-northeast-2.config_sns_topic
+    "ap-northeast-3" = module.config_baseline_ap-northeast-3.config_sns_topic
     "ap-south-1"     = module.config_baseline_ap-south-1.config_sns_topic
     "ap-southeast-1" = module.config_baseline_ap-southeast-1.config_sns_topic
     "ap-southeast-2" = module.config_baseline_ap-southeast-2.config_sns_topic
@@ -109,6 +111,7 @@ output "guardduty_detector" {
   value = {
     "ap-northeast-1" = module.guardduty_baseline_ap-northeast-1.guardduty_detector
     "ap-northeast-2" = module.guardduty_baseline_ap-northeast-2.guardduty_detector
+    "ap-northeast-3" = module.guardduty_baseline_ap-northeast-3.guardduty_detector
     "ap-south-1"     = module.guardduty_baseline_ap-south-1.guardduty_detector
     "ap-southeast-1" = module.guardduty_baseline_ap-southeast-1.guardduty_detector
     "ap-southeast-2" = module.guardduty_baseline_ap-southeast-2.guardduty_detector
@@ -149,6 +152,7 @@ output "vpc_flow_logs_group" {
   value = local.is_cw_logs ? {
     "ap-northeast-1" = module.vpc_baseline_ap-northeast-1.vpc_flow_logs_group
     "ap-northeast-2" = module.vpc_baseline_ap-northeast-2.vpc_flow_logs_group
+    "ap-northeast-3" = module.vpc_baseline_ap-northeast-3.vpc_flow_logs_group
     "ap-south-1"     = module.vpc_baseline_ap-south-1.vpc_flow_logs_group
     "ap-southeast-1" = module.vpc_baseline_ap-southeast-1.vpc_flow_logs_group
     "ap-southeast-2" = module.vpc_baseline_ap-southeast-2.vpc_flow_logs_group
@@ -172,6 +176,7 @@ output "default_vpc" {
   value = {
     "ap-northeast-1" = module.vpc_baseline_ap-northeast-1.default_vpc
     "ap-northeast-2" = module.vpc_baseline_ap-northeast-2.default_vpc
+    "ap-northeast-3" = module.vpc_baseline_ap-northeast-3.default_vpc
     "ap-south-1"     = module.vpc_baseline_ap-south-1.default_vpc
     "ap-southeast-1" = module.vpc_baseline_ap-southeast-1.default_vpc
     "ap-southeast-2" = module.vpc_baseline_ap-southeast-2.default_vpc
@@ -195,6 +200,7 @@ output "default_security_group" {
   value = {
     "ap-northeast-1" = module.vpc_baseline_ap-northeast-1.default_security_group
     "ap-northeast-2" = module.vpc_baseline_ap-northeast-2.default_security_group
+    "ap-northeast-3" = module.vpc_baseline_ap-northeast-3.default_security_group
     "ap-south-1"     = module.vpc_baseline_ap-south-1.default_security_group
     "ap-southeast-1" = module.vpc_baseline_ap-southeast-1.default_security_group
     "ap-southeast-2" = module.vpc_baseline_ap-southeast-2.default_security_group
@@ -218,6 +224,7 @@ output "default_network_acl" {
   value = {
     "ap-northeast-1" = module.vpc_baseline_ap-northeast-1.default_network_acl
     "ap-northeast-2" = module.vpc_baseline_ap-northeast-2.default_network_acl
+    "ap-northeast-3" = module.vpc_baseline_ap-northeast-3.default_network_acl
     "ap-south-1"     = module.vpc_baseline_ap-south-1.default_network_acl
     "ap-southeast-1" = module.vpc_baseline_ap-southeast-1.default_network_acl
     "ap-southeast-2" = module.vpc_baseline_ap-southeast-2.default_network_acl
@@ -241,6 +248,7 @@ output "default_route_table" {
   value = {
     "ap-northeast-1" = module.vpc_baseline_ap-northeast-1.default_route_table
     "ap-northeast-2" = module.vpc_baseline_ap-northeast-2.default_route_table
+    "ap-northeast-3" = module.vpc_baseline_ap-northeast-3.default_route_table
     "ap-south-1"     = module.vpc_baseline_ap-south-1.default_route_table
     "ap-southeast-1" = module.vpc_baseline_ap-southeast-1.default_route_table
     "ap-southeast-2" = module.vpc_baseline_ap-southeast-2.default_route_table

--- a/securityhub_baselines.tf
+++ b/securityhub_baselines.tf
@@ -32,6 +32,20 @@ module "securityhub_baseline_ap-northeast-2" {
   member_accounts                  = local.securityhub_member_accounts
 }
 
+module "securityhub_baseline_ap-northeast-3" {
+  source = "./modules/securityhub-baseline"
+
+  providers = {
+    aws = aws.ap-northeast-3
+  }
+
+  enabled                          = contains(var.target_regions, "ap-northeast-3")
+  enable_cis_standard              = var.securityhub_enable_cis_standard
+  enable_pci_dss_standard          = var.securityhub_enable_pci_dss_standard
+  enable_aws_foundational_standard = var.securityhub_enable_aws_foundational_standard
+  member_accounts                  = local.securityhub_member_accounts
+}
+
 module "securityhub_baseline_ap-south-1" {
   source = "./modules/securityhub-baseline"
 

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,7 @@ variable "target_regions" {
   default = [
     "ap-northeast-1",
     "ap-northeast-2",
+    "ap-northeast-3",
     "ap-south-1",
     "ap-southeast-1",
     "ap-southeast-2",

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0.0"
+      version = ">= 3.39.0"
     }
   }
 }

--- a/vpc_baselines.tf
+++ b/vpc_baselines.tf
@@ -100,6 +100,26 @@ module "vpc_baseline_ap-northeast-2" {
   tags = var.tags
 }
 
+module "vpc_baseline_ap-northeast-3" {
+  source = "./modules/vpc-baseline"
+
+  providers = {
+    aws = aws.ap-northeast-3
+  }
+
+  enabled                     = contains(var.target_regions, "ap-northeast-3")
+  enable_flow_logs            = var.vpc_enable_flow_logs
+  flow_logs_destination_type  = var.vpc_flow_logs_destination_type
+  flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
+  flow_logs_iam_role_arn      = local.is_cw_logs ? aws_iam_role.flow_logs_publisher[0].arn : null
+  flow_logs_retention_in_days = var.vpc_flow_logs_retention_in_days
+  flow_logs_s3_arn            = local.flow_logs_s3_arn
+  flow_logs_s3_key_prefix     = var.vpc_flow_logs_s3_key_prefix
+
+
+  tags = var.tags
+}
+
 module "vpc_baseline_ap-south-1" {
   source = "./modules/vpc-baseline"
 


### PR DESCRIPTION
This PR is enabling new generally available region `ap-northeast-3` (Osaka) and updating minimum version of AWS provider